### PR TITLE
Update guide

### DIFF
--- a/docs/configure/spell-check.md
+++ b/docs/configure/spell-check.md
@@ -8,8 +8,7 @@ sidebar_position: 5
 
 This template repository uses [CSpell](https://cspell.org/) to check for misspelled words
 throughout the documentation.
-CSpell automatically runs when you run [`git commit`](../create/run-in-development.md#pre-commit-hooks)
-or if you manually run [`npm run lint:spelling`](../create/run-in-development.md#npm-run-lintspelling).
+CSpell runs when you run [`npm run lint:spelling`](../create/run-in-development.md#npm-run-lintspelling).
 
 You usually don't need to edit the [`.cspell.json`](../create/repo-structure.md#-cspelljson) file itself.
 However, you can add ignore paths or files if needed.

--- a/docs/contribute/preview.md
+++ b/docs/contribute/preview.md
@@ -27,7 +27,7 @@ npm start
 ```
 
 :::note
-If you make changes to the [redirects](configure-docusaurus.md#redirects), you can preview them by
+If you make changes to the [redirects](../create/configure-docusaurus.md#redirects), you can preview them by
 running `npm run build && npm run serve`.
 :::
 
@@ -44,6 +44,6 @@ yarn start
 ```
 
 :::note
-If you make changes to the [redirects](configure-docusaurus.md#redirects), you can preview them by
+If you make changes to the [redirects](../create/configure-docusaurus.md#redirects), you can preview them by
 running `yarn build && yarn serve`.
 :::

--- a/docs/contribute/style-guide.md
+++ b/docs/contribute/style-guide.md
@@ -14,6 +14,7 @@ Refer to the following guides when writing, editing, or reviewing doc content:
   function-based docs.
 - [**ConsenSys Editorial Style Guide**](https://docs.google.com/document/d/1smRdw4TUIpz9re_o0_0DKdH_nK6cSPMJOK6BcbhjJ7Y/edit?usp=sharing) -
   Refer to this guide for spelling and usage of blockchain-related terms.
+  This guide is only available to internal ConsenSys contributors.
 
 The following section also highlights the top five style tips from these guides.
 

--- a/docs/contribute/submit-a-contribution.md
+++ b/docs/contribute/submit-a-contribution.md
@@ -93,7 +93,7 @@ To contribute changes:
 
 11. If your PR fails any checks, displayed at the bottom of the PR page, fix those errors.
     If you want to include a new word that causes a [spell check](../configure/spell-check.md) error,
-    you can add that word to the `project-words.txt` file.
+    you can add that word to the [`project-words.txt`](../create/repo-structure.md#-project-wordstxt) file.
 
 12. For most doc repositories, specific reviewers are automatically requested when you submit a PR.
     You can request additional reviewers in the right sidebar of your PR – for example, the original

--- a/docs/contribute/submit-a-contribution.md
+++ b/docs/contribute/submit-a-contribution.md
@@ -98,7 +98,7 @@ To contribute changes:
 12. For most doc repositories, specific reviewers are automatically requested when you submit a PR.
     You can request additional reviewers in the right sidebar of your PR – for example, the original
     issue raiser.
-    Make any required changes to your PR based on reviewer feedback, repeating steps 5–7.
+    Make any required changes to your PR based on reviewer feedback, repeating steps 7–9.
 
 13. After your PR is approved by two reviewers, all checks have passed, and your branch has no
     conflicts with the main branch, you can merge your PR.

--- a/docs/contribute/submit-a-contribution.md
+++ b/docs/contribute/submit-a-contribution.md
@@ -71,7 +71,7 @@ To contribute changes:
 
    :::caution important
    If you delete, rename, or move a documentation file, make sure to add a
-   [redirect](configure-docusaurus.md#redirects).
+   [redirect](../create/configure-docusaurus.md#redirects).
    :::
 
 8. [Preview your changes locally](preview.md) to check that the changes render correctly.

--- a/docs/create/configure-docusaurus.md
+++ b/docs/create/configure-docusaurus.md
@@ -1,6 +1,6 @@
 ---
 description: Configure your Docusaurus site and use Docusaurus Markdown features.
-sidebar_position: 4
+sidebar_position: 1.5
 ---
 
 # Configure Docusaurus

--- a/docs/create/repo-structure.md
+++ b/docs/create/repo-structure.md
@@ -167,8 +167,7 @@ It requires installing [nvm](https://github.com/nvm-sh/nvm#installing-and-updati
 We recommend using [Prettier](https://prettier.io/) to format all files.
 Anything not covered in `.editorconfig` is overridden or specified in this Prettier configuration file.
 
-When you `git commit` on this repo, `lint-staged` runs `npm run format`, which runs Prettier to
-format and save those changes.
+Running [`npm run format`](run-in-development.md#npm-run-format) runs Prettier to format and save those changes.
 
 ## 📄 `.releaserc.js`
 
@@ -227,7 +226,7 @@ Please add your project words here periodically as this is the master file that 
 
 ## 📄 `sidebars.js`
 
-Separate `.js` file used by Docusaurus to provide [sidebar configuration](../contribute/configure-docusaurus.md#sidebar).
+Separate `.js` file used by Docusaurus to provide [sidebar configuration](configure-docusaurus.md#sidebar).
 
 ## 📄 `tsconfig.json`
 

--- a/docs/create/repo-structure.md
+++ b/docs/create/repo-structure.md
@@ -222,7 +222,6 @@ related dependency configurations.
 
 Used by CSpell in the `.cspell.json` configuration file with additional project words that should
 not be flagged as misspelling when linting.
-Please add your project words here periodically as this is the master file that all repositories use.
 
 ## 📄 `sidebars.js`
 


### PR DESCRIPTION
- Remove references to `git commit` pre-commit command.
- Move **Configure Docusaurus** topic to the **Create a new doc site** section.
- Add note that ConsenSys Editorial Style Guide is only available to internal contributors.