### PR TITLE
updates path per current dir

### DIFF
--- a/docs/contribute/run-vale.md
+++ b/docs/contribute/run-vale.md
@@ -41,7 +41,7 @@ view issues in real-time.
     variable to the location of the file in the repo. For example, on macOS this is:
 
     ```bash
-    export VALE_CONFIG_PATH="/Users/{user-name}/documentation/docs-gha/spelling/.vale.ini"
+    export VALE_CONFIG_PATH="/Users/{user-name}/documentation/docs-gha/docs-spelling-check/.vale.ini"
     ```
 
      :::note
@@ -78,7 +78,7 @@ You must have the [Visual Studio (VS) Code](https://code.visualstudio.com) edito
 1. [Install the VS Code extension](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode)
 
 1. In the settings for the Vale VS Code extension, set the location of the `.vale.ini` file, and
-    enable the spell check. The `.vale.ini` file is located within the `spelling` directory in the
+    enable the spell check. The `.vale.ini` file is located within the `docs-spelling-check` directory in the
     `docs-gha` repo that you cloned onto your local.
 
     ![VS Code extension settings](../assets/vs-code-ext.png)


### PR DESCRIPTION
Fixes #60 dir has changed in gha since docs written

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Vale setup docs to reference `.vale.ini` in `docs-spelling-check` (CLI env var and VS Code settings).
> 
> - **Documentation**:
>   - Update `.vale.ini` path references from `spelling` to `docs-spelling-check` in `docs/contribute/run-vale.md`.
>     - Adjust `VALE_CONFIG_PATH` example for CLI usage.
>     - Update VS Code extension settings instructions to the new directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 937ce2c1bddff7cf01a040f3ec520a08fae9b33f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->